### PR TITLE
fix: issue with site_url is not defined

### DIFF
--- a/src/inline_svg/util.py
+++ b/src/inline_svg/util.py
@@ -81,7 +81,9 @@ def _patch_style(svg_soup):
 
 
 def _get_local_file_from_url(url: str, files: MkDocsFiles, config: InlineSvgConfig) -> MkDocsFile | None:
-    return files.get_file_from_path(url.removeprefix(config.site_url))
+    if config.site_url is not None:
+        url = url.removeprefix(config.site_url)
+    return files.get_file_from_path(url)
 
 
 def get_svg_data(url: str, files: MkDocsFiles, config: InlineSvgConfig) -> str | None:


### PR DESCRIPTION
Before this fix the plugin can raise 

```
  File "/home/vald/.local/lib/python3.10/site-packages/inline_svg/util.py", line 88, in get_svg_data
    static_file = _get_local_file_from_url(url, files, config)
  File "/home/vald/.local/lib/python3.10/site-packages/inline_svg/util.py", line 84, in _get_local_file_from_url
    return files.get_file_from_path(url.removeprefix(config.site_url))
TypeError: removeprefix() argument must be str, not None
```

When the site_url is not set. It can be null: https://www.mkdocs.org/user-guide/configuration/#site_url

